### PR TITLE
Add mailcap to fix some filebrowser preview issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ ADD Caddyfile SecureCaddyfile /usr/local/caddy/
 
 RUN adduser -D -u 1000 junv \
   && apk update \
-  && apk add runit shadow wget bash curl openrc gnupg aria2 tar --no-cache \
+  && apk add runit shadow wget bash curl openrc gnupg aria2 tar mailcap --no-cache \
   && caddy_tag=v1.0.4 \
   && wget -N https://github.com/caddyserver/caddy/releases/download/${caddy_tag}/caddy_${caddy_tag}_linux_amd64.tar.gz \
   && tar -zxvf caddy_${caddy_tag}_linux_amd64.tar.gz \


### PR DESCRIPTION
fix missing `/etc/mime.types`  that causes filebrowser to not recoginizing some videos as video files and showing no inline preview window.